### PR TITLE
Fix signup

### DIFF
--- a/src/app/layout/signup-form/signup-form.tsx
+++ b/src/app/layout/signup-form/signup-form.tsx
@@ -38,8 +38,9 @@ const SignupForm = () => {
   const watchZip = useWatch({ control, name: 'addresses.0.postalCode' });
 
   useEffect(() => {
+    setSelectedShippingCountry(true);
     if (isShippingPress) {
-      setValue('addresses.1.country', isShipping ? 'DE' : watchCountryBilling, {
+      setValue('addresses.1.country', watchCountryBilling, {
         shouldValidate: isShipping,
         shouldDirty: false,
         shouldTouch: false,
@@ -70,9 +71,13 @@ const SignupForm = () => {
     }
   }, [watchCountryBilling, selectedCountry, setValue]);
   useEffect(() => {
-    if (selectedShippingCountry) {
+    if (selectedShippingCountry && isShipping) {
       setValue('addresses.1.postalCode', '', { shouldValidate: true, shouldDirty: true, shouldTouch: true });
       setSelectedShippingCountry(false);
+    } else if (selectedShippingCountry && !isShipping) {
+      setValue('addresses.1.postalCode', watchZip, { shouldValidate: false, shouldDirty: false, shouldTouch: false });
+      setSelectedShippingCountry(false);
+      trigger(['addresses.1.country', 'addresses.1.postalCode']);
     }
   }, [watchCountryShipping, selectedShippingCountry, setValue]);
   useEffect(() => {


### PR DESCRIPTION
fix for shipping address validation:
- when pressing Add Shipping address button, all data in shipping inputs delete, shipping country (select) setting to "Germany" value
- all inputs work correctly
- form can validate with shipping address or without it
